### PR TITLE
Make it possible to use AMD and Intel GPUs as well as Apple Silicon (backend-only)

### DIFF
--- a/MangaJaNaiConverterGui/backend/src/accelerator_detection.py
+++ b/MangaJaNaiConverterGui/backend/src/accelerator_detection.py
@@ -1,0 +1,320 @@
+"""
+Comprehensive accelerator detection for PyTorch backend.
+Supports all available PyTorch accelerators in PyTorch 2.7+
+"""
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from enum import Enum
+from functools import cached_property
+from typing import Any, Optional, Sequence
+
+import torch
+from sanic.log import logger
+
+
+class AcceleratorType(Enum):
+    """Supported accelerator types"""
+    CPU = "cpu"
+    CUDA = "cuda"
+    ROCM = "rocm"  # AMD GPUs using ROCm
+    MPS = "mps"    # Apple Metal Performance Shaders
+    XPU = "xpu"    # Intel GPUs
+
+
+@dataclass(frozen=True)
+class AcceleratorDevice:
+    """Information about an accelerator device"""
+    type: AcceleratorType
+    index: int
+    name: str
+    memory_total: Optional[int] = None
+    memory_free: Optional[int] = None
+    supports_fp16: bool = False
+    supports_bf16: bool = False
+    device_string: str = ""
+
+    def __post_init__(self):
+        if not self.device_string:
+            if self.type == AcceleratorType.CPU:
+                object.__setattr__(self, "device_string", "cpu")
+            else:
+                object.__setattr__(self, "device_string", f"{self.type.value}:{self.index}")
+
+    @property
+    def torch_device(self) -> torch.device:
+        """Get the corresponding torch.device"""
+        return torch.device(self.device_string)
+
+
+class AcceleratorDetector:
+    """Detects and manages available accelerators"""
+
+    def __init__(self):
+        self._devices: Optional[list[AcceleratorDevice]] = None
+
+    @cached_property
+    def available_devices(self) -> list[AcceleratorDevice]:
+        """Get all available accelerator devices"""
+        if self._devices is None:
+            self._devices = self._detect_all_devices()
+        return self._devices
+
+    def _detect_all_devices(self) -> list[AcceleratorDevice]:
+        """Detect all available accelerator devices"""
+        devices = []
+        
+        # Always add CPU
+        devices.append(AcceleratorDevice(
+            type=AcceleratorType.CPU,
+            index=0,
+            name="CPU",
+            supports_fp16=False,  # PyTorch 2.7+ doesn't support FP16 on CPU
+            supports_bf16=True,   # CPU supports bfloat16
+        ))
+
+        # Detect CUDA devices
+        devices.extend(self._detect_cuda_devices())
+
+        # Detect ROCm devices (ROCm uses CUDA API)
+        devices.extend(self._detect_rocm_devices())
+
+        # Detect Apple MPS
+        devices.extend(self._detect_mps_devices())
+
+        # Detect Intel XPU
+        devices.extend(self._detect_xpu_devices())
+
+        return devices
+
+    def _detect_cuda_devices(self) -> list[AcceleratorDevice]:
+        """Detect NVIDIA CUDA devices"""
+        devices = []
+        try:
+            if torch.cuda.is_available():
+                for i in range(torch.cuda.device_count()):
+                    try:
+                        device_props = torch.cuda.get_device_properties(i)
+                        memory_info = torch.cuda.mem_get_info(i)
+                        
+                        # Determine FP16 support based on architecture
+                        supports_fp16 = self._cuda_supports_fp16(device_props, i)
+                        supports_bf16 = self._cuda_supports_bf16(device_props)
+
+                        devices.append(AcceleratorDevice(
+                            type=AcceleratorType.CUDA,
+                            index=i,
+                            name=device_props.name,
+                            memory_total=device_props.total_memory,
+                            memory_free=memory_info[0],
+                            supports_fp16=supports_fp16,
+                            supports_bf16=supports_bf16,
+                        ))
+                        logger.info(f"Detected CUDA device {i}: {device_props.name}")
+                    except Exception as e:
+                        logger.warning(f"Failed to get info for CUDA device {i}: {e}")
+        except Exception as e:
+            logger.info(f"CUDA not available: {e}")
+        
+        return devices
+
+    def _detect_rocm_devices(self) -> list[AcceleratorDevice]:
+        """Detect AMD ROCm devices"""
+        devices = []
+        try:
+            # ROCm devices appear as CUDA devices due to HIP/CUDA compatibility
+            # Check if we're actually running on ROCm
+            if hasattr(torch.version, 'hip') and torch.version.hip is not None:
+                # This is ROCm, re-categorize CUDA devices as ROCm
+                if torch.cuda.is_available():
+                    for i in range(torch.cuda.device_count()):
+                        try:
+                            device_props = torch.cuda.get_device_properties(i)
+                            memory_info = torch.cuda.mem_get_info(i)
+                            
+                            devices.append(AcceleratorDevice(
+                                type=AcceleratorType.ROCM,
+                                index=i,
+                                name=device_props.name,
+                                memory_total=device_props.total_memory,
+                                memory_free=memory_info[0],
+                                supports_fp16=True,  # Most modern AMD GPUs support FP16
+                                supports_bf16=True,  # Modern AMD GPUs support bfloat16
+                                device_string=f"cuda:{i}",  # ROCm uses cuda device string
+                            ))
+                            logger.info(f"Detected ROCm device {i}: {device_props.name}")
+                        except Exception as e:
+                            logger.warning(f"Failed to get info for ROCm device {i}: {e}")
+        except Exception as e:
+            logger.debug(f"ROCm detection failed: {e}")
+        
+        return devices
+
+    def _detect_mps_devices(self) -> list[AcceleratorDevice]:
+        """Detect Apple Metal Performance Shaders devices"""
+        devices = []
+        try:
+            if (hasattr(torch, 'backends') and 
+                hasattr(torch.backends, 'mps') and 
+                torch.backends.mps.is_built() and 
+                torch.backends.mps.is_available()):
+                
+                devices.append(AcceleratorDevice(
+                    type=AcceleratorType.MPS,
+                    index=0,
+                    name="Apple Metal GPU",
+                    supports_fp16=True,   # MPS supports FP16
+                    supports_bf16=False,  # MPS doesn't support bfloat16 yet
+                    device_string="mps",
+                ))
+                logger.info("Detected Apple MPS device")
+        except Exception as e:
+            logger.debug(f"MPS detection failed: {e}")
+        
+        return devices
+
+    def _detect_xpu_devices(self) -> list[AcceleratorDevice]:
+        """Detect Intel XPU devices"""
+        devices = []
+        try:
+            if hasattr(torch, 'xpu') and torch.xpu.is_available():
+                device_count = torch.xpu.device_count()
+                for i in range(device_count):
+                    try:
+                        device_name = torch.xpu.get_device_name(i)
+                        # Try to get memory info if available
+                        memory_info = None
+                        try:
+                            memory_info = torch.xpu.mem_get_info(i)
+                        except Exception:
+                            pass
+
+                        devices.append(AcceleratorDevice(
+                            type=AcceleratorType.XPU,
+                            index=i,
+                            name=device_name,
+                            memory_total=memory_info[1] if memory_info else None,
+                            memory_free=memory_info[0] if memory_info else None,
+                            supports_fp16=True,   # Intel XPU supports FP16
+                            supports_bf16=True,   # Intel XPU supports bfloat16
+                        ))
+                        logger.info(f"Detected Intel XPU device {i}: {device_name}")
+                    except Exception as e:
+                        logger.warning(f"Failed to get info for XPU device {i}: {e}")
+        except Exception as e:
+            logger.debug(f"XPU detection failed: {e}")
+        
+        return devices
+
+    def _cuda_supports_fp16(self, device_props: Any, device_index: int) -> bool:
+        """Check if CUDA device supports FP16"""
+        try:
+            # Check compute capability
+            major, minor = device_props.major, device_props.minor
+            compute_capability = major * 10 + minor
+            
+            # FP16 is supported on:
+            # - Volta (7.0+) and newer architectures
+            # - Some Turing cards (RTX series, not GTX 16xx)
+            if compute_capability >= 70:  # Volta and newer
+                return True
+            elif compute_capability >= 75:  # Turing
+                # For Turing, check if it's RTX (supports FP16) or GTX 16xx (doesn't)
+                return "RTX" in device_props.name
+            else:
+                return False
+        except Exception:
+            # Fallback: try to actually use FP16
+            try:
+                test_tensor = torch.tensor([1.0], dtype=torch.float16, device=f"cuda:{device_index}")
+                return True
+            except Exception:
+                return False
+
+    def _cuda_supports_bf16(self, device_props: Any) -> bool:
+        """Check if CUDA device supports bfloat16"""
+        try:
+            # bfloat16 is supported on Ampere (8.0+) and newer
+            major, minor = device_props.major, device_props.minor
+            compute_capability = major * 10 + minor
+            return compute_capability >= 80
+        except Exception:
+            return False
+
+    def get_devices_by_type(self, accelerator_type: AcceleratorType) -> list[AcceleratorDevice]:
+        """Get all devices of a specific type"""
+        return [device for device in self.available_devices if device.type == accelerator_type]
+
+    def get_best_device(self, prefer_gpu: bool = True) -> AcceleratorDevice:
+        """Get the best available device"""
+        if not prefer_gpu:
+            return self.get_cpu_device()
+
+        # Priority order: CUDA > XPU > MPS > ROCm > CPU
+        for device_type in [AcceleratorType.CUDA, AcceleratorType.XPU, AcceleratorType.MPS, 
+                           AcceleratorType.ROCM]:
+            devices = self.get_devices_by_type(device_type)
+            if devices:
+                return devices[0]  # Return the first device of this type
+
+        return self.get_cpu_device()
+
+    def get_cpu_device(self) -> AcceleratorDevice:
+        """Get the CPU device"""
+        cpu_devices = self.get_devices_by_type(AcceleratorType.CPU)
+        return cpu_devices[0] if cpu_devices else AcceleratorDevice(
+            type=AcceleratorType.CPU, index=0, name="CPU"
+        )
+
+    def get_device_by_index(self, device_type: AcceleratorType, index: int) -> Optional[AcceleratorDevice]:
+        """Get a specific device by type and index"""
+        devices = self.get_devices_by_type(device_type)
+        for device in devices:
+            if device.index == index:
+                return device
+        return None
+
+
+def get_autocast_device_type(device: torch.device) -> str:
+    """Get the correct device type string for torch.autocast"""
+    device_type = device.type
+    
+    # Map device types to autocast device types
+    if device_type in ["cuda", "rocm"]:  # ROCm uses cuda device type
+        return "cuda"
+    elif device_type == "xpu":
+        return "xpu"
+    elif device_type == "mps":
+        # MPS doesn't support autocast yet, use cpu
+        return "cpu"
+    else:
+        return "cpu"
+
+
+def is_device_type_supported_for_autocast(device: torch.device) -> bool:
+    """Check if device type supports autocast"""
+    device_type = device.type
+    return device_type in ["cuda", "xpu"]
+
+
+# Global detector instance
+_detector: Optional[AcceleratorDetector] = None
+
+
+def get_accelerator_detector() -> AcceleratorDetector:
+    """Get the global accelerator detector instance"""
+    global _detector
+    if _detector is None:
+        _detector = AcceleratorDetector()
+    return _detector
+
+
+def get_available_devices() -> list[AcceleratorDevice]:
+    """Convenience function to get all available devices"""
+    return get_accelerator_detector().available_devices
+
+
+def get_best_device(prefer_gpu: bool = True) -> AcceleratorDevice:
+    """Convenience function to get the best available device"""
+    return get_accelerator_detector().get_best_device(prefer_gpu)

--- a/MangaJaNaiConverterGui/backend/src/device_list.py
+++ b/MangaJaNaiConverterGui/backend/src/device_list.py
@@ -1,8 +1,43 @@
 import torch
+from accelerator_detection import get_accelerator_detector
 
+# Get all available accelerator devices
+detector = get_accelerator_detector()
+all_devices = detector.available_devices
+
+device_list = []
+for device in all_devices:
+    device_info = {
+        "type": device.type.value,
+        "index": device.index,
+        "name": device.name,
+        "device_string": device.device_string,
+        "supports_fp16": device.supports_fp16,
+        "supports_bf16": device.supports_bf16,
+    }
+    if device.memory_total:
+        device_info["memory_total"] = device.memory_total
+    if device.memory_free:
+        device_info["memory_free"] = device.memory_free
+    
+    device_list.append(device_info)
+
+print("Available accelerator devices:")
+for i, device_info in enumerate(device_list):
+    memory_info = ""
+    if "memory_total" in device_info:
+        total_gb = device_info["memory_total"] / (1024**3)
+        memory_info = f" ({total_gb:.1f}GB)"
+    
+    print(f"  {i}: {device_info['name']} ({device_info['type'].upper()}:{device_info['index']}){memory_info}")
+    print(f"     Device String: {device_info['device_string']}")
+    print(f"     FP16 Support: {device_info['supports_fp16']}")
+    print(f"     BF16 Support: {device_info['supports_bf16']}")
+
+# Legacy CUDA device list for backward compatibility
 gpu_list = []
 for i in range(torch.cuda.device_count()):
     device_name = torch.cuda.get_device_properties(i).name
     gpu_list.append(device_name)
 
-print(gpu_list)
+print(f"\nLegacy CUDA GPU list: {gpu_list}")

--- a/MangaJaNaiConverterGui/backend/src/packages/chaiNNer_pytorch/settings.py
+++ b/MangaJaNaiConverterGui/backend/src/packages/chaiNNer_pytorch/settings.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 import torch
+from accelerator_detection import AcceleratorType, get_accelerator_detector
 from gpu import nvidia
 from sanic.log import logger
 from system import is_arm_mac
@@ -9,39 +10,66 @@ from api import DropdownSetting, NodeContext, NumberSetting, ToggleSetting
 
 from . import package
 
-if not is_arm_mac:
-    gpu_list = []
-    for i in range(torch.cuda.device_count()):
-        device_name = torch.cuda.get_device_properties(i).name
-        gpu_list.append(device_name)
+# Get all available accelerator devices
+detector = get_accelerator_detector()
+all_devices = detector.available_devices
 
+# Create device options, excluding CPU for the dropdown
+gpu_devices = [device for device in all_devices if device.type != AcceleratorType.CPU]
+
+if gpu_devices:
     package.add_setting(
         DropdownSetting(
-            label="GPU",
-            key="gpu_index",
+            label="Accelerator Device",
+            key="accelerator_device_index",
             description=(
-                "Which GPU to use for PyTorch. This is only relevant if you have"
-                " multiple GPUs."
+                "Which accelerator device to use for PyTorch. This includes NVIDIA CUDA, "
+                "AMD ROCm, Intel XPU, Apple MPS, and other supported accelerators."
             ),
-            options=[{"label": x, "value": str(i)} for i, x in enumerate(gpu_list)],
+            options=[{
+                "label": f"{device.name} ({device.type.value.upper()}:{device.index})", 
+                "value": str(i)
+            } for i, device in enumerate(gpu_devices)],
             default="0",
         )
     )
+
+# Legacy GPU index setting for backward compatibility (CUDA only)
+if not is_arm_mac:
+    cuda_devices = detector.get_devices_by_type(AcceleratorType.CUDA)
+    if cuda_devices:
+        package.add_setting(
+            DropdownSetting(
+                label="CUDA GPU (Legacy)",
+                key="gpu_index",
+                description=(
+                    "Which CUDA GPU to use for PyTorch. This setting is deprecated - "
+                    "use 'Accelerator Device' instead for full accelerator support."
+                ),
+                options=[{"label": device.name, "value": str(device.index)} for device in cuda_devices],
+                default="0",
+            )
+        )
 
 package.add_setting(
     ToggleSetting(
         label="Use CPU Mode",
         key="use_cpu",
         description=(
-            "Use CPU for PyTorch instead of GPU. This is much slower and not"
-            " recommended."
+            "Use CPU for PyTorch instead of accelerator devices. This is much slower "
+            "and not recommended unless you have no compatible accelerator."
         ),
         default=False,
     ),
 )
 
+# Determine default FP16 setting based on available devices
 should_fp16 = False
-if nvidia.is_available:
+gpu_devices = [device for device in all_devices if device.type != AcceleratorType.CPU]
+if gpu_devices:
+    # Enable FP16 by default if any GPU supports it
+    should_fp16 = any(device.supports_fp16 for device in gpu_devices)
+elif nvidia.is_available:
     should_fp16 = nvidia.all_support_fp16
 else:
     should_fp16 = is_arm_mac
@@ -51,14 +79,9 @@ package.add_setting(
         label="Use FP16 Mode",
         key="use_fp16",
         description=(
-            "Runs PyTorch in half-precision (FP16) mode for reduced RAM usage but falls"
-            " back to full-precision (FP32) mode when CPU mode is selected."
-            if is_arm_mac
-            else (
-                "Runs PyTorch in half-precision (FP16) mode for less VRAM usage. RTX"
-                " GPUs also get a speedup. It falls back to full-precision (FP32)"
-                " mode when CPU mode is selected."
-            )
+            "Runs PyTorch in half-precision (FP16) mode for reduced memory usage. "
+            "Automatically falls back to bfloat16 or FP32 when FP16 is not supported. "
+            "Falls back to full-precision (FP32) mode when CPU mode is selected."
         ),
         default=should_fp16,
     ),
@@ -75,12 +98,18 @@ package.add_setting(
     )
 )
 
-if nvidia.is_available:
+# Add cache wipe setting for accelerator types that support it
+has_accelerator_with_cache = any(
+    device.type in [AcceleratorType.CUDA, AcceleratorType.ROCM, AcceleratorType.XPU] 
+    for device in all_devices
+)
+
+if has_accelerator_with_cache:
     package.add_setting(
         ToggleSetting(
-            label="Force CUDA Cache Wipe (not recommended)",
+            label="Force Accelerator Cache Wipe (not recommended)",
             key="force_cache_wipe",
-            description="Clears PyTorch's CUDA cache after each inference. This is NOT recommended, by us or PyTorch's developers, as it basically interferes with how PyTorch is intended to work and can significantly slow down inference time. Only enable this if you're experiencing issues with VRAM allocation.",
+            description="Clears PyTorch's accelerator cache after each inference. This is NOT recommended, as it interferes with how PyTorch is intended to work and can significantly slow down inference time. Only enable this if you're experiencing issues with memory allocation.",
             default=False,
         )
     )
@@ -90,39 +119,67 @@ if nvidia.is_available:
 class PyTorchSettings:
     use_cpu: bool
     use_fp16: bool
-    gpu_index: int
+    gpu_index: int  # Legacy CUDA index
+    accelerator_device_index: int  # New unified accelerator index
     budget_limit: int
     force_cache_wipe: bool = False
 
-    # PyTorch 2.0 does not support FP16 when using CPU
+    # PyTorch 2.7 does not support FP16 when using CPU
     def __post_init__(self):
         if self.use_cpu and self.use_fp16:
             object.__setattr__(self, "use_fp16", False)
-            logger.info("Falling back to FP32 mode.")
+            logger.info("Falling back to FP32 mode for CPU.")
 
     @property
     def device(self) -> torch.device:
+        """Get the appropriate torch device"""
+        detector = get_accelerator_detector()
+        
         # CPU override
         if self.use_cpu:
-            device = "cpu"
-        # Check for Nvidia CUDA
-        elif torch.cuda.is_available() and torch.cuda.device_count() > 0:
-            device = f"cuda:{self.gpu_index}"
-        # Check for Apple MPS
-        elif (
-            hasattr(torch, "backends")
-            and hasattr(torch.backends, "mps")
-            and torch.backends.mps.is_built()
-            and torch.backends.mps.is_available()
-        ):  # type: ignore -- older pytorch versions dont support this technically
-            device = "mps"
-        # Check for DirectML
-        elif hasattr(torch, "dml") and torch.dml.is_available():  # type: ignore
-            device = "dml"
-        else:
-            device = "cpu"
+            return torch.device("cpu")
+        
+        # Try to use the new accelerator device index first
+        gpu_devices = [device for device in detector.available_devices if device.type != AcceleratorType.CPU]
+        
+        if gpu_devices and 0 <= self.accelerator_device_index < len(gpu_devices):
+            selected_device = gpu_devices[self.accelerator_device_index]
+            return selected_device.torch_device
+        
+        # Fallback to legacy CUDA device selection for backward compatibility
+        cuda_devices = detector.get_devices_by_type(AcceleratorType.CUDA)
+        if cuda_devices and 0 <= self.gpu_index < len(cuda_devices):
+            return torch.device(f"cuda:{self.gpu_index}")
+        
+        # Fallback to best available device
+        best_device = detector.get_best_device(prefer_gpu=True)
+        if best_device.type != AcceleratorType.CPU:
+            return best_device.torch_device
+        
+        # Final fallback to CPU
+        return torch.device("cpu")
 
-        return torch.device(device)
+    @property
+    def accelerator_device(self) -> 'AcceleratorDevice':
+        """Get the selected accelerator device info"""
+        detector = get_accelerator_detector()
+        
+        if self.use_cpu:
+            return detector.get_cpu_device()
+        
+        # Try to use the new accelerator device index first
+        gpu_devices = [device for device in detector.available_devices if device.type != AcceleratorType.CPU]
+        
+        if gpu_devices and 0 <= self.accelerator_device_index < len(gpu_devices):
+            return gpu_devices[self.accelerator_device_index]
+        
+        # Fallback to legacy CUDA device selection
+        cuda_devices = detector.get_devices_by_type(AcceleratorType.CUDA)
+        if cuda_devices and 0 <= self.gpu_index < len(cuda_devices):
+            return cuda_devices[self.gpu_index]
+        
+        # Fallback to best available device
+        return detector.get_best_device(prefer_gpu=True)
 
 
 def get_settings(context: NodeContext) -> PyTorchSettings:
@@ -132,6 +189,7 @@ def get_settings(context: NodeContext) -> PyTorchSettings:
         use_cpu=settings.get_bool("use_cpu", False),
         use_fp16=settings.get_bool("use_fp16", False),
         gpu_index=settings.get_int("gpu_index", 0, parse_str=True),
+        accelerator_device_index=settings.get_int("accelerator_device_index", 0, parse_str=True),
         budget_limit=settings.get_int("budget_limit", 0, parse_str=True),
         force_cache_wipe=settings.get_bool("force_cache_wipe", False),
     )

--- a/MangaJaNaiConverterGui/backend/src/test_accelerators.py
+++ b/MangaJaNaiConverterGui/backend/src/test_accelerators.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Test script for the new accelerator detection system.
+"""
+
+import sys
+import torch
+from accelerator_detection import get_accelerator_detector, AcceleratorType
+
+def test_accelerator_detection():
+    """Test the accelerator detection system"""
+    print("=== PyTorch Accelerator Detection Test ===\n")
+    
+    # Get detector
+    detector = get_accelerator_detector()
+    
+    # Show PyTorch version
+    print(f"PyTorch Version: {torch.__version__}")
+    if hasattr(torch.version, 'hip') and torch.version.hip:
+        print(f"ROCm Version: {torch.version.hip}")
+    print()
+    
+    # Get all devices
+    all_devices = detector.available_devices
+    
+    print(f"Detected {len(all_devices)} device(s):\n")
+    
+    for i, device in enumerate(all_devices):
+        print(f"Device {i}: {device.name}")
+        print(f"  Type: {device.type.value.upper()}")
+        print(f"  Index: {device.index}")
+        print(f"  Device String: {device.device_string}")
+        print(f"  Torch Device: {device.torch_device}")
+        print(f"  FP16 Support: {device.supports_fp16}")
+        print(f"  BF16 Support: {device.supports_bf16}")
+        
+        if device.memory_total:
+            total_gb = device.memory_total / (1024**3)
+            print(f"  Total Memory: {total_gb:.2f} GB")
+        
+        if device.memory_free:
+            free_gb = device.memory_free / (1024**3)
+            print(f"  Free Memory: {free_gb:.2f} GB")
+        
+        print()
+    
+    # Test device selection
+    print("=== Device Selection Tests ===\n")
+    
+    best_device = detector.get_best_device()
+    print(f"Best Device: {best_device.name} ({best_device.type.value})")
+    
+    cpu_device = detector.get_cpu_device()
+    print(f"CPU Device: {cpu_device.name}")
+    
+    # Test by type
+    for device_type in AcceleratorType:
+        devices = detector.get_devices_by_type(device_type)
+        if devices:
+            print(f"{device_type.value.upper()} devices: {len(devices)}")
+            for device in devices:
+                print(f"  - {device.name}")
+    
+    print("\n=== Simple Tensor Test ===\n")
+    
+    # Test with best device
+    try:
+        test_device = best_device.torch_device
+        print(f"Testing tensor creation on {test_device}")
+        
+        # Create a simple tensor
+        x = torch.tensor([1.0, 2.0, 3.0]).to(test_device)
+        y = torch.tensor([4.0, 5.0, 6.0]).to(test_device)
+        z = x + y
+        
+        print(f"Tensor computation successful: {z.cpu().tolist()}")
+        
+        # Test autocast if supported
+        from accelerator_detection import get_autocast_device_type, is_device_type_supported_for_autocast
+        
+        autocast_device_type = get_autocast_device_type(test_device)
+        autocast_supported = is_device_type_supported_for_autocast(test_device)
+        
+        print(f"Autocast device type: {autocast_device_type}")
+        print(f"Autocast supported: {autocast_supported}")
+        
+        if autocast_supported:
+            with torch.autocast(device_type=autocast_device_type, dtype=torch.float16, enabled=True):
+                z_autocast = x * y
+                print(f"Autocast computation successful: {z_autocast.cpu().tolist()}")
+        
+    except Exception as e:
+        print(f"Tensor test failed: {e}")
+    
+    print("\n=== Test Completed ===")
+
+
+if __name__ == "__main__":
+    test_accelerator_detection()


### PR DESCRIPTION
Closes #72

I plan to eventually get a AMD graphics card and was thinking about using a Intel Arc GPU for my NAS, so tried to make the backend run on non-NVIDIA-GPUs.

Ironically, I only have access to NVIDIA GPUs (RTX 2070 Super and GTX 1070), but I can confirm that this works on those without regression. I have tested it for the past few days on my [manga library management app](https://github.com/Lolle2000la/MangaIngestWithUpscaling), where I include the backend from this repo. In it, I included my forked version to use these changes.

If you have access to a Intel or AMD GPU (or a Apple Silicon device, i.e. a MacBook, Mac Mini, etc.), please help me by testing these changes. For that you need to run install the right packages, preferably installed into a virtual environment:

#### AMD

```sh
pip install torch==2.7.1 torchvision==0.22.1 --extra-index-url https://download.pytorch.org/whl/rocm6.3 chainner_ext==0.3.10 numpy==2.2.5 opencv-python-headless==4.11.0.86 psutil==6.0.0 pynvml==11.5.3 pyvips==3.0.0 pyvips-binary==8.16.1 rarfile==4.2 sanic==24.6.0 spandrel_extra_arches==0.2.0 spandrel==0.4.1 --no-warn-script-location
```

#### Intel GPU

```sh
pip install torch==2.7.1 torchvision==0.22.1 --extra-index-url https://download.pytorch.org/whl/xpu chainner_ext==0.3.10 numpy==2.2.5 opencv-python-headless==4.11.0.86 psutil==6.0.0 pynvml==11.5.3 pyvips==3.0.0 pyvips-binary==8.16.1 rarfile==4.2 sanic==24.6.0 spandrel_extra_arches==0.2.0 spandrel==0.4.1 --no-warn-script-location
```

#### Apple Silicon (Mac)

```sh
# no extra index necessary
pip install torch==2.7.1 torchvision==0.22.1 chainner_ext==0.3.10 numpy==2.2.5 opencv-python-headless==4.11.0.86 psutil==6.0.0 pynvml==11.5.3 pyvips==3.0.0 pyvips-binary==8.16.1 rarfile==4.2 sanic==24.6.0 spandrel_extra_arches==0.2.0 spandrel==0.4.1 --no-warn-script-location
```